### PR TITLE
Add setProperty() result logging

### DIFF
--- a/main/src/main/java/webapp/runner/launch/Main.java
+++ b/main/src/main/java/webapp/runner/launch/Main.java
@@ -98,8 +98,12 @@ public class Main {
       for (final Map.Entry<String, String> entry : commandLineParams.attributes.entrySet()) {
         final String key = entry.getKey();
         final String value = entry.getValue();
-        System.out.println("property: " + key + " - " + value);
-        nioConnector.setProperty(entry.getKey(), entry.getValue());
+
+        if (nioConnector.setProperty(entry.getKey(), entry.getValue())) {
+          System.out.println("property: " + key + " - " + value + "(OK)");
+        } else {
+          System.out.println("property: " + key + " - " + value + " (Could not be set, no effect!)");
+        }
       }
     }
 


### PR DESCRIPTION
Users can set any connector attribute with `-ApropertyName=propertyValue`. Currently, if an unknown attribute name (or incompatible value type) is specified, the error is silently ignored. This leaves the user with no way of telling if the attribute was successfully set.

This PR adds user logging of the result of the `setProperty` call.