### PR TITLE
Add --session-store-ssl-endpoint-identification

### DIFF
--- a/main/src/main/java/webapp/runner/launch/CommandLineParams.java
+++ b/main/src/main/java/webapp/runner/launch/CommandLineParams.java
@@ -49,6 +49,9 @@ public class CommandLineParams {
   @Parameter(names = "--session-store-ignore-pattern", description = "Request pattern to not track sessions for. Valid only with memcache session store. (default is '.*\\.(png|gif|jpg|css|js)$'. Has no effect for 'redis')")
   public String sessionStoreIgnorePattern = ".*\\.(png|gif|jpg|css|js)$";
 
+  @Parameter(names = "--session-store-ssl-endpoint-identification", description = "Enables or disables SSL endpoint identification for the redis session store. (default is true. Has no effect for 'memcache')", arity = 1)
+  public boolean sessionStoreSslEndpointIdentification = true;
+
   @Parameter(names = "--help", help = true)
   public boolean help;
 

--- a/redis/src/main/java/webapp/runner/launch/RedisSessionStore.java
+++ b/redis/src/main/java/webapp/runner/launch/RedisSessionStore.java
@@ -50,6 +50,7 @@ public class RedisSessionStore extends SessionStore {
 
       Config config = new Config();
       SingleServerConfig serverConfig = config.useSingleServer()
+          .setSslEnableEndpointIdentification(commandLineParams.sessionStoreSslEndpointIdentification)
           .setAddress(redisUriWithoutAuth.toString())
           .setConnectionPoolSize(commandLineParams.sessionStorePoolSize)
           .setConnectionMinimumIdleSize(commandLineParams.sessionStorePoolSize)


### PR DESCRIPTION
When using self-signed certificates, SSL endpoint validation will fail when the certificate is not present in the keystore. This PR adds the `--session-store-ssl-endpoint-identification` flag that allows users to disable SSL endpoint verification. By default, SSL endpoint validation is still enabled.

This is necessary for Heroku Redis which uses changing self-signed certificates.

Closes GUS-W-10292226
See https://github.com/heroku/webapp-runner/pull/253 for the 9.0 version of this PR