### PR TITLE
Bump commons-io from 2.6 to 2.11.0

### DIFF
--- a/main/src/test/java/webapp/runner/launch/TomcatBaseDirResolutionTest.java
+++ b/main/src/test/java/webapp/runner/launch/TomcatBaseDirResolutionTest.java
@@ -43,7 +43,7 @@ public class TomcatBaseDirResolutionTest {
 	@Test
 	public void testBaseDirAlreadyExistsAsFile() throws Exception {
 		BASE_DIR.getParentFile().mkdirs();
-		new PrintWriter(BASE_DIR).append("");
+		new PrintWriter(BASE_DIR).append("").close();
 		assertTrue(BASE_DIR.isFile());
 
 		try {

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
   <properties>
     <assembly.plugin.version>2.6</assembly.plugin.version>
     <release.plugin.version>2.5.3</release.plugin.version>
-    <commons-io.version>2.6</commons-io.version>
+    <commons-io.version>2.11.0</commons-io.version>
     <gpg.plugin.version>1.6</gpg.plugin.version>
     <compiler.plugin.version>3.7.0</compiler.plugin.version>
     <tomcat-embed-logging-juli.version>9.0.0.M6</tomcat-embed-logging-juli.version>


### PR DESCRIPTION
1. Bump commons-io from 2.6 to 2.11.0.
2. Fix TomcatBaseDirResolutionTest test class.