### PR TITLE
Update Tomcat dependency to 9.0.65

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>webapp-runner-parent</artifactId>
     <groupId>com.heroku</groupId>
-    <version>9.0.52.2-SNAPSHOT</version>
+    <version>9.0.65.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>webapp-runner-parent</artifactId>
     <groupId>com.heroku</groupId>
-    <version>9.0.52.2-SNAPSHOT</version>
+    <version>9.0.65.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/memcached/pom.xml
+++ b/memcached/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>webapp-runner-parent</artifactId>
     <groupId>com.heroku</groupId>
-    <version>9.0.52.2-SNAPSHOT</version>
+    <version>9.0.65.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.heroku</groupId>
   <artifactId>webapp-runner-parent</artifactId>
-  <version>9.0.52.2-SNAPSHOT</version>
+  <version>9.0.65.0</version>
   <packaging>pom</packaging>
   <name>webapp-runner-parent</name>
   <description>Lightweight Application Launcher. Launch your webapp in the most popular open source web container available with a single command.</description>
@@ -71,7 +71,7 @@
     <redisson.version>3.11.5</redisson.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <invoker.plugin.version>2.0.0</invoker.plugin.version>
-    <tomcat.version>9.0.52</tomcat.version>
+    <tomcat.version>9.0.65</tomcat.version>
     <javadoc.plugin.version>2.10.4</javadoc.plugin.version>
     <nexus-staging.plugin.version>1.6.8</nexus-staging.plugin.version>
     <testng.version>6.14.3</testng.version>

--- a/redis/pom.xml
+++ b/redis/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>webapp-runner-parent</artifactId>
     <groupId>com.heroku</groupId>
-    <version>9.0.52.2-SNAPSHOT</version>
+    <version>9.0.65.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Hi and thanks for the useful library. I'm using it via https://github.com/earldouglas/xsbt-web-plugin. After recently updating my build environment from Java 8 to Java 11, I started getting this error when the SBT plugin called webapp-runner:

```
java.lang.ClassCastException: class java.io.ObjectStreamClass$Caches$1 cannot be cast to class java.util.Map (java.io.ObjectStreamClass$Caches$1 and java.util.Map are in module java.base of loader 'bootstrap')
        at org.apache.catalina.loader.WebappClassLoaderBase.clearCache(WebappClassLoaderBase.java:2282)
        at org.apache.catalina.loader.WebappClassLoaderBase.clearReferencesObjectStreamClassCaches(WebappClassLoaderBase.java:2257)
        at org.apache.catalina.loader.WebappClassLoaderBase.clearReferences(WebappClassLoaderBase.java:1627)
        at org.apache.catalina.loader.WebappClassLoaderBase.stop(WebappClassLoaderBase.java:1555)
        at org.apache.catalina.loader.WebappLoader.stopInternal(WebappLoader.java:461)
```

Looks like it was a bug in Tomcat which was fixed in the past few months - https://github.com/apache/tomcat/commit/385d4095ccf354c2f9c527283f3ed2832de1a1cf - in their 9.0.64 release. This PR goes to 9.0.65 since that's the most recent at the time of writing.