### PR TITLE
Fix pom.xml for Maven Central release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <developers>
         <developer>
             <name>Manuel Fuchs</name>
-            <organization>salesforce.com, inc.</organization>
+            <organization>Salesforce, Inc.</organization>
         </developer>
     </developers>
     <mailingLists>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,17 @@
         available with a single command.
     </description>
     <url>https://heroku.github.com/webapp-runner</url>
+    <licenses>
+        <license>
+            <name>BSD-3-Clause</name>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <name>Manuel Fuchs</name>
+            <organization>salesforce.com, inc.</organization>
+        </developer>
+    </developers>
     <mailingLists>
         <mailingList>
             <name>Webapp runner issues</name>
@@ -170,7 +181,7 @@
                         </goals>
                         <configuration>
                             <source>1.8</source>
-                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <doclint>none</doclint>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
I was a little too eager to remove some of the metadata from `pom.xml`. This PR re-adds missing metadata that is required to publish to Maven Central.