### PR TITLE
Added new command line parameter 'secure-error-report-valve'

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ Usage: <main class> [options]
     --use-body-encoding-for-uri
       Set if the entity body encoding should be used for the URI.
       Default: false
+    --secure-error-report-valve
+      Set true to set ErrorReportValve properties showReport and showServerInfo to false. This protects from Apache stacktrace logging of malicious http requests. 
+      Default: false
     -A
       Allows setting HTTP connector attributes. For example: -Acompression=on
       Syntax: -Akey=value

--- a/webapp-runner-main/src/main/java/webapp/runner/launch/CommandLineParams.java
+++ b/webapp-runner-main/src/main/java/webapp/runner/launch/CommandLineParams.java
@@ -131,7 +131,10 @@ public class CommandLineParams {
               + " jar file)")
   public String tomcatUsersLocation;
 
-  @Parameter(names = "--secure-error-report-valve", description = "Set true to set ErrorReportValve properties showReport and showServerInfo to false")
+  @Parameter(
+      names = "--secure-error-report-valve",
+      description =
+          "Set true to set ErrorReportValve properties showReport and showServerInfo to false")
   public boolean secureErrorReportValve = false;
 
   // Not actually useful because it can only be set to true. We're keeping it here for backward

--- a/webapp-runner-main/src/main/java/webapp/runner/launch/CommandLineParams.java
+++ b/webapp-runner-main/src/main/java/webapp/runner/launch/CommandLineParams.java
@@ -131,6 +131,9 @@ public class CommandLineParams {
               + " jar file)")
   public String tomcatUsersLocation;
 
+  @Parameter(names = "--secure-error-report-valve", description = "Set true to set ErrorReportValve properties showReport and showServerInfo to false")
+  public boolean secureErrorReportValve = false;
+
   // Not actually useful because it can only be set to true. We're keeping it here for backward
   // compatibility.
   @Parameter(names = "--expand-war", hidden = true)

--- a/webapp-runner-main/src/main/java/webapp/runner/launch/Main.java
+++ b/webapp-runner-main/src/main/java/webapp/runner/launch/Main.java
@@ -44,6 +44,7 @@ import org.apache.catalina.startup.ExpandWar;
 import org.apache.catalina.startup.Tomcat;
 import org.apache.catalina.users.MemoryUserDatabase;
 import org.apache.catalina.users.MemoryUserDatabaseFactory;
+import org.apache.catalina.valves.ErrorReportValve;
 import org.apache.coyote.AbstractProtocol;
 import org.apache.coyote.ProtocolHandler;
 import org.apache.tomcat.util.descriptor.web.LoginConfig;
@@ -298,6 +299,13 @@ public class Main {
       host.getPipeline().addValve(valve);
     }
 
+    if (commandLineParams.secureErrorReportValve) {
+      Host host = tomcat.getHost();
+      ErrorReportValve valve = new ErrorReportValve();
+      valve.setShowReport(false);
+      valve.setShowServerInfo(false);
+      host.getPipeline().addValve(valve);
+    }
     // start the server
     tomcat.start();
 


### PR DESCRIPTION
There are special malicious request for which Tomcat usually logs stacktraces to the caller. Try a Null Code attack like https://XX.herokuapp.com/application/anything%00 . Tomcat will always answer it using the properties in the ErrorReportValve.

These requests aren't even dispatched to the deployed applications and thus error pages don't solve the problem.
This pull requests adds a new option to set the properties showReport and showServerInfo of ErrorReportValve to false.

Please also merge into tomcat9 branch

See https://help.heroku.com/tickets/1027939
