### PR TITLE
Redis Session Storage: Add required `fst` dependency

### DIFF
--- a/webapp-runner-redis/pom.xml
+++ b/webapp-runner-redis/pom.xml
@@ -24,5 +24,11 @@
             <artifactId>redisson-tomcat-9</artifactId>
             <version>${redisson.version}</version>
         </dependency>
+        <!-- This dependency is required by redisson when the FstCodec is used -->
+        <dependency>
+            <groupId>de.ruedigermoeller</groupId>
+            <artifactId>fst</artifactId>
+            <version>2.57</version>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
When the Redis store is used, we historically use the `FstCodec` which is deprecated. Redisson no longer includes the underlying dependency due to the deprecation so we need to add it manually. Ideally, we would stop using `FstCodec`, but that would mean that the data written to Redis previously would not be deserializable anymore. Since this is a very impactful breaking change, let's hold off until we migrate to Tomcat 10.

Ref: GUS-W-12671321