### PR TITLE
Fix webapp-runner-10 CHANGELOG

### DIFF
--- a/webapp-runner-10/CHANGELOG.md
+++ b/webapp-runner-10/CHANGELOG.md
@@ -10,4 +10,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Initial release with Tomcat 10.1 support. ([#397](https://github.com/heroku/webapp-runner/pull/397))
 
 [unreleased]: https://github.com/heroku/webapp-runner/compare/v10.1.16.0...HEAD
-[10.1.16.0]: https://github.com/heroku/webapp-runner/compare/v10.0.0.0...v10.1.16.0
+[10.1.16.0]: https://github.com/heroku/webapp-runner/compare/v9.0.83.1...v10.1.16.0


### PR DESCRIPTION
I had to create a bogus release so that the release automation works correctly. It requires a "previous version" which doesn't exist for the first release. This PR fixes the CHANGELOG to point to the correct tag. The bogus release (and its tag) have already been removed.