### PR TITLE
Configure dependabot to ignore major Tomcat versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/webapp-runner-9"
     schedule:
       interval: "monthly"
+    ignore:
+      - dependency-name: "tomcat.version"
+        update-types: ["version-update:semver-major"]
     labels:
       - "skip changelog"
       - "tomcat 9"
@@ -11,6 +14,9 @@ updates:
     directory: "/webapp-runner-10"
     schedule:
       interval: "monthly"
+    ignore:
+      - dependency-name: "tomcat.version"
+        update-types: ["version-update:semver-major"]
     labels:
       - "skip changelog"
       - "tomcat 10"


### PR DESCRIPTION
This project uses separate Maven projects for each supported Tomcat major version. These projects should never update the major version of Tomcat as we would create a new Maven project for such updates. 

This PR configures dependabot to ignore major version updates for Tomcat.