### PR TITLE
Use correct output from `create-github-app-token`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2.0.6
         with:
-          token: ${{ steps.generate-token.outputs.app_token }}
+          token: ${{ steps.generate-token.outputs.token }}
           tag_name: v${{ steps.new-version.outputs.version }}
           body: ${{ steps.changelog-entry.outputs.content }}
 


### PR DESCRIPTION
This is a follow-up fix to #491.

The correct output name is `token`, see:
https://github.com/actions/create-github-app-token/tree/v1/?tab=readme-ov-file#outputs

Spotted when working on another PR, since I have the GitHub Actions VSCode plugin installed, which lints the workflow files and highlights issues inline.