### PR TITLE
Correct the groupId

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ for any external dependencies other than those specified in your build to run yo
               <configuration>
                   <artifactItems>
                       <artifactItem>
-                          <groupId>com.github.heroku</groupId>
+                          <groupId>com.heroku</groupId>
                           <artifactId>webapp-runner</artifactId>
                           <version>${webapp-runner.version}</version>
                           <destFileName>webapp-runner.jar</destFileName>
@@ -73,7 +73,7 @@ them by using `webapp-runner-main` instead of `webapp-runner`:
 
 ```xml
 <artifactItem>
-    <groupId>com.github.heroku</groupId>
+    <groupId>com.heroku</groupId>
     <artifactId>webapp-runner-main</artifactId>
     <version>${webapp-runner.version}</version>
     <destFileName>webapp-runner.jar</destFileName>


### PR DESCRIPTION
The `groupId` in both *pom.xml* files is `com.heroku`, which matches the published artifacts:

https://search.maven.org/search?q=g:com.heroku%20a:webapp-runner

This updates the documentation to match.

Note that there are no artifacts published under `com.github.heroku`:

https://search.maven.org/search?q=g:com.github.heroku