### PR TITLE
Fix POM configuration for Central Publishing Portal validation

### DIFF
--- a/webapp-runner-9/webapp-runner-main/pom.xml
+++ b/webapp-runner-9/webapp-runner-main/pom.xml
@@ -6,6 +6,7 @@
         <groupId>com.heroku</groupId>
         <version>9.0.106.0</version>
     </parent>
+    <name>webapp-runner-main</name>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>webapp-runner-main</artifactId>
     <build>

--- a/webapp-runner-9/webapp-runner-memcached/pom.xml
+++ b/webapp-runner-9/webapp-runner-memcached/pom.xml
@@ -6,6 +6,7 @@
         <groupId>com.heroku</groupId>
         <version>9.0.106.0</version>
     </parent>
+    <name>webapp-runner-memcached</name>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>webapp-runner-memcached</artifactId>
     <dependencies>

--- a/webapp-runner-9/webapp-runner-redis/pom.xml
+++ b/webapp-runner-9/webapp-runner-redis/pom.xml
@@ -6,6 +6,7 @@
         <groupId>com.heroku</groupId>
         <version>9.0.106.0</version>
     </parent>
+    <name>webapp-runner-redis</name>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>webapp-runner-redis</artifactId>
     <dependencies>

--- a/webapp-runner-9/webapp-runner/pom.xml
+++ b/webapp-runner-9/webapp-runner/pom.xml
@@ -6,6 +6,7 @@
         <groupId>com.heroku</groupId>
         <version>9.0.106.0</version>
     </parent>
+    <name>webapp-runner</name>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>webapp-runner</artifactId>
     <build>


### PR DESCRIPTION
### Background
The Central Publishing Portal enforces stricter component validation requirements compared to OSSRH. Following the changes introduced in #632, our current POM configuration no longer passes these validation checks.

### Changes
This PR adjusts the POM configuration to meet the stricter validation requirements of the Central Publishing Portal.

### Scope
This update specifically targets webapp-runner `9.x` only, as the repository is currently in transition between webapp-runner releases.