### PR TITLE
Fix POM configuration for Central Publishing Portal validation

### DIFF
--- a/webapp-runner-10/webapp-runner-main/pom.xml
+++ b/webapp-runner-10/webapp-runner-main/pom.xml
@@ -6,6 +6,7 @@
         <groupId>com.heroku</groupId>
         <version>10.1.42.0-SNAPSHOT</version>
     </parent>
+    <name>webapp-runner-main</name>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>webapp-runner-main</artifactId>
     <build>

--- a/webapp-runner-10/webapp-runner-memcached/pom.xml
+++ b/webapp-runner-10/webapp-runner-memcached/pom.xml
@@ -6,6 +6,7 @@
         <groupId>com.heroku</groupId>
         <version>10.1.42.0-SNAPSHOT</version>
     </parent>
+    <name>webapp-runner-memcached</name>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>webapp-runner-memcached</artifactId>
     <dependencies>

--- a/webapp-runner-10/webapp-runner-redis/pom.xml
+++ b/webapp-runner-10/webapp-runner-redis/pom.xml
@@ -6,6 +6,7 @@
         <groupId>com.heroku</groupId>
         <version>10.1.42.0-SNAPSHOT</version>
     </parent>
+    <name>webapp-runner-redis</name>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>webapp-runner-redis</artifactId>
     <dependencies>

--- a/webapp-runner-10/webapp-runner/pom.xml
+++ b/webapp-runner-10/webapp-runner/pom.xml
@@ -6,6 +6,7 @@
         <groupId>com.heroku</groupId>
         <version>10.1.42.0-SNAPSHOT</version>
     </parent>
+    <name>webapp-runner</name>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>webapp-runner</artifactId>
     <build>


### PR DESCRIPTION
### Background
The Central Publishing Portal enforces stricter component validation requirements compared to OSSRH. Following the changes introduced in #632, our current POM configuration no longer passes these validation checks.

### Changes
This PR adjusts the POM configuration to meet the stricter validation requirements of the Central Publishing Portal.

See #634 for the webapp-runner `9.x` version of this PR.